### PR TITLE
Update deprecated recommended rule

### DIFF
--- a/templates/biome/biome.json
+++ b/templates/biome/biome.json
@@ -3,7 +3,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"preset": "recommended"
 		}
 	}
 }


### PR DESCRIPTION
Updated the "recommended" template rule to use the 2.5+ syntax via preset.

Since this breaks backward compatibility, a separate version of biome.json is required, if it's somethig we care about. We can then determine which version to load during the CLI version selection step.